### PR TITLE
Added index referencing build artifacts

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,6 @@
+module.exports = [
+    'AddressRegistry',
+    'OlympiaToken',
+    'PlayToken',
+    'RewardClaimHandler'
+].reduce((o, n) => (o[n] = require(`./build/contracts/${ n }.json`), o), {})


### PR DESCRIPTION
Importing this package with `require('@gnosis.pm/olympia-token')` will now return an object:

```js
{
  PlayToken: { /* contents of play token truffle artifact here */ },
  ... // etc.
}
```